### PR TITLE
FEATURE: Translate CR Nodes automatically.

### DIFF
--- a/Classes/Domain/Service/DeepLService.php
+++ b/Classes/Domain/Service/DeepLService.php
@@ -3,6 +3,11 @@
 namespace CodeQ\DeepLTranslationHelper\Domain\Service;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Client\Browser;
+use Neos\Flow\Http\Client\CurlEngine;
+use Neos\Http\Factories\ServerRequestFactory;
+use Neos\Http\Factories\StreamFactory;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -24,6 +29,18 @@ class DeepLService
     protected $logger;
 
     /**
+     * @Flow\Inject
+     * @var ServerRequestFactory
+     */
+    protected $serverRequestFactory;
+
+    /**
+     * @Flow\Inject
+     * @var StreamFactory
+     */
+    protected $streamFactory;
+
+    /**
      * @param string[] $texts
      * @param string $targetLanguage
      * @param string|null $sourceLanguage
@@ -31,78 +48,67 @@ class DeepLService
      */
     public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
     {
+        // store keys and values seperately for later reunion
         $keys = array_keys($texts);
         $values = array_values($texts);
 
         $baseUri = $this->settings['useFreeApi'] ? $this->settings['baseUriFree'] : $this->settings['baseUri'];
 
-        $curlHandle = curl_init($baseUri . 'translate');
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 0);
-        curl_setopt($curlHandle, CURLOPT_HTTPHEADER, ['Expect:']);
-        curl_setopt($curlHandle, CURLOPT_POST, true);
-        curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-        curl_setopt($curlHandle, CURLOPT_HTTPHEADER, [
-            'Accept: */*',
-            'Content-Type: application/x-www-form-urlencoded',
-            sprintf('Authorization: DeepL-Auth-Key %s', $this->settings['apiAuthKey'])
-        ]);
-
-        // create request body ... neither psr nor guzzle can create the body format that
-        // is required here
+        // request body ... this has to be done manually because of the non php ish format
+        // with multiple text arguments
         $body = http_build_query($this->settings['defaultOptions']);
         if ($sourceLanguage) {
             $body .= '&source_lang=' . urlencode($sourceLanguage);
         }
         $body .= '&target_lang=' . urlencode($targetLanguage);
-
         foreach($values as $part) {
             $body .= '&text=' . urlencode($part);
         }
 
-        curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $body);
+        $apiRequest = $this->serverRequestFactory->createServerRequest('POST', $baseUri . 'translate')
+            ->withHeader('Accept', 'application/json')
+            ->withHeader('Authorization', sprintf('DeepL-Auth-Key %s', $this->settings['apiAuthKey']))
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($this->streamFactory->createStream($body));
 
-        // return
-        $curlResult = curl_exec($curlHandle);
-        if ($curlResult === false) {
-            return $texts;
-        }
+        $browser = new Browser();
+        $engine = new CurlEngine();
+        $engine->setOption(CURLOPT_TIMEOUT, 0);
+        $browser->setRequestEngine($engine);
 
-        $status = curl_getinfo($curlHandle, CURLINFO_RESPONSE_CODE);
+        /**
+         * @var ResponseInterface $apiResponse
+         */
+        $apiResponse = $browser->sendRequest($apiRequest);
 
-        if ($status != 200) {
-            if ($status === 403) {
+        if ($apiResponse->getStatusCode() == 200) {
+            $returnedData = json_decode($apiResponse->getBody()->getContents(), true);
+            if (is_null($returnedData)) {
+                return $texts;
+            }
+            $translations = array_map(
+                function($part) {
+                    return $part['text'];
+                },
+                $returnedData['translations']
+            );
+            return array_combine($keys, $translations);
+        } else {
+            if ($apiResponse->getStatusCode() === 403) {
                 $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
-            } elseif ($status === 429) {
+            } elseif ($apiResponse->getStatusCode() === 429) {
                 $this->logger->warning('You sent too many requests to the DeepL API, we\'ll retry to connect to the API on the next request');
-            } elseif ($status === 456) {
+            } elseif ($apiResponse->getStatusCode() === 456) {
                 $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
-            } elseif ($status === 400) {
+            } elseif ($apiResponse->getStatusCode() === 400) {
                 $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
                     'sourceLanguage' => $sourceLanguage,
                     'targetLanguage' => $targetLanguage
                 ]);
             } else {
-                $this->logger->warning('Unexpected status from Deepl API', ['status' => $status]);
+                $this->logger->warning('Unexpected status from Deepl API', ['status' => $apiResponse->getStatusCode()]);
             }
             return $texts;
         }
-
-        curl_close($curlHandle);
-
-        $returnedData = json_decode($curlResult, true);
-
-        if (is_null($returnedData)) {
-            return $texts;
-        }
-
-        $translations = array_map(
-            function($part) {
-                return $part['text'];
-            },
-            $returnedData['translations']
-        );
-
-        return array_combine($keys, $translations);
     }
 }

--- a/Classes/Domain/Service/DeepLService.php
+++ b/Classes/Domain/Service/DeepLService.php
@@ -3,9 +3,6 @@
 namespace CodeQ\DeepLTranslationHelper\Domain\Service;
 
 use Neos\Flow\Annotations as Flow;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -13,10 +10,6 @@ use Psr\Log\LoggerInterface;
  */
 class DeepLService
 {
-    /**
-     * @var Client|null
-     */
-    protected ?Client $deeplClient = null;
 
     /**
      * @var array
@@ -30,80 +23,86 @@ class DeepLService
      */
     protected $logger;
 
-    protected function initializeObject()
-    {
-        $this->deeplClient = new Client([
-            'base_uri' => $this->settings['baseUri'],
-            'timeout' => 0,
-            'headers' => [
-                'Authorization' => sprintf('DeepL-Auth-Key %s', $this->settings['apiAuthKey'])
-            ]
-        ]);
-    }
-
     /**
-     * @param string      $text
-     * @param string      $targetLanguage
-     *
+     * @param string[] $texts
+     * @param string $targetLanguage
      * @param string|null $sourceLanguage
-     *
-     * @return string
+     * @return array
      */
-    public function translate(
-        string $text,
-        string $targetLanguage,
-        string $sourceLanguage = null
-    ): string {
-        if ($sourceLanguage === $targetLanguage) {
-            return $text;
+    public function translate(array $texts, string $targetLanguage, ?string $sourceLanguage = null): array
+    {
+        $keys = array_keys($texts);
+        $values = array_values($texts);
+
+        $baseUri = $this->settings['useFreeApi'] ? $this->settings['baseUriFree'] : $this->settings['baseUri'];
+
+        $curlHandle = curl_init($baseUri . 'translate');
+        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 0);
+        curl_setopt($curlHandle, CURLOPT_HTTPHEADER, ['Expect:']);
+        curl_setopt($curlHandle, CURLOPT_POST, true);
+        curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curlHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+        curl_setopt($curlHandle, CURLOPT_HTTPHEADER, [
+            'Accept: */*',
+            'Content-Type: application/x-www-form-urlencoded',
+            sprintf('Authorization: DeepL-Auth-Key %s', $this->settings['apiAuthKey'])
+        ]);
+
+        // create request body ... neither psr nor guzzle can create the body format that
+        // is required here
+        $body = http_build_query($this->settings['defaultOptions']);
+        if ($sourceLanguage) {
+            $body .= '&source_lang=' . urlencode($sourceLanguage);
+        }
+        $body .= '&target_lang=' . urlencode($targetLanguage);
+
+        foreach($values as $part) {
+            $body .= '&text=' . urlencode($part);
         }
 
-        try {
-            $response = $this->deeplClient->get('translate', [
-                'query' => [
-                    'text' => $text,
-                    'source_lang' => $sourceLanguage,
-                    'target_lang' => $targetLanguage,
-                    'tag_handling' => 'xml',
-                    'split_sentences' => 'nonewlines'
-                ]
-            ]);
+        curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $body);
 
-            $responseBody = json_decode($response->getBody()->getContents(),
-                true);
-            $translations = $responseBody['translations'];
-            $translatedText = $translations[0]['text'];
-        } catch (ClientException $e) {
-            if ($e->getResponse()->getStatusCode() === 403) {
+        // return
+        $curlResult = curl_exec($curlHandle);
+        if ($curlResult === false) {
+            return $texts;
+        }
+
+        $status = curl_getinfo($curlHandle, CURLINFO_RESPONSE_CODE);
+
+        if ($status != 200) {
+            if ($status === 403) {
                 $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
-            } elseif ($e->getResponse()->getStatusCode() === 429) {
+            } elseif ($status === 429) {
                 $this->logger->warning('You sent too many requests to the DeepL API, we\'ll retry to connect to the API on the next request');
-            } elseif ($e->getResponse()->getStatusCode() === 456) {
+            } elseif ($status === 456) {
                 $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
-            } elseif ($e->getResponse()->getStatusCode() === 400) {
+            } elseif ($status === 400) {
                 $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
                     'sourceLanguage' => $sourceLanguage,
                     'targetLanguage' => $targetLanguage
                 ]);
             } else {
-                $this->logger->warning('The DeepL API request did not complete successfully, see status code and message below.', [
-                    'statusCode' => $e->getResponse()->getStatusCode(),
-                    'message' => $e->getResponse()->getBody()->getContents()
-                ]);
+                $this->logger->warning('Unexpected status from Deepl API', ['status' => $status]);
             }
-
-            // If the call went wrong, return the original text
-            $translatedText = $text;
-        } catch (GuzzleException $e) {
-            $this->logger->warning('The DeepL API request did not complete successfully, see status code and message below.', [
-                'statusCode' => $e->getResponse()->getStatusCode(),
-                'message' => $e->getResponse()->getBody()->getContents()
-            ]);
-
-            // If the call went wrong, return the original text
-            $translatedText = $text;
+            return $texts;
         }
 
-        return $translatedText;
+        curl_close($curlHandle);
+
+        $returnedData = json_decode($curlResult, true);
+
+        if (is_null($returnedData)) {
+            return $texts;
+        }
+
+        $translations = array_map(
+            function($part) {
+                return $part['text'];
+            },
+            $returnedData['translations']
+        );
+
+        return array_combine($keys, $translations);
     }
 }

--- a/Classes/Domain/Service/DeepLService.php
+++ b/Classes/Domain/Service/DeepLService.php
@@ -2,12 +2,10 @@
 
 namespace CodeQ\DeepLTranslationHelper\Domain\Service;
 
+use Neos\Flow\Annotations as Flow;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
-use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Aop\Exception\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,11 +23,6 @@ class DeepLService
      * @Flow\InjectConfiguration(path="DeepLService")
      */
     protected array $settings;
-
-    /**
-     * @var VariableFrontend
-     */
-    protected $translationCache;
 
     /**
      * @Flow\Inject
@@ -65,65 +58,50 @@ class DeepLService
             return $text;
         }
 
-        // See: https://ideone.com/embed/0iwuGn
-        $cacheIdentifier = sprintf('%s-%s', hash('haval256,3', $text),
-            $targetLanguage);
-        $translatedText = $this->translationCache->get($cacheIdentifier);
+        try {
+            $response = $this->deeplClient->get('translate', [
+                'query' => [
+                    'text' => $text,
+                    'source_lang' => $sourceLanguage,
+                    'target_lang' => $targetLanguage,
+                    'tag_handling' => 'xml',
+                    'split_sentences' => 'nonewlines'
+                ]
+            ]);
 
-        if ($translatedText === false) {
-            try {
-                $response = $this->deeplClient->get('translate', [
-                    'query' => [
-                        'text' => $text,
-                        'source_lang' => $sourceLanguage,
-                        'target_lang' => $targetLanguage,
-                        'tag_handling' => 'xml',
-                        'split_sentences' => 'nonewlines'
-                    ]
+            $responseBody = json_decode($response->getBody()->getContents(),
+                true);
+            $translations = $responseBody['translations'];
+            $translatedText = $translations[0]['text'];
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
+            } elseif ($e->getResponse()->getStatusCode() === 429) {
+                $this->logger->warning('You sent too many requests to the DeepL API, we\'ll retry to connect to the API on the next request');
+            } elseif ($e->getResponse()->getStatusCode() === 456) {
+                $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
+            } elseif ($e->getResponse()->getStatusCode() === 400) {
+                $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
+                    'sourceLanguage' => $sourceLanguage,
+                    'targetLanguage' => $targetLanguage
                 ]);
-
-                $responseBody = json_decode($response->getBody()->getContents(),
-                    true);
-                $translations = $responseBody['translations'];
-                $translatedText = $translations[0]['text'];
-                try {
-                    $this->translationCache->set($cacheIdentifier,
-                        $translatedText);
-                } catch (\Neos\Cache\Exception $e) {
-                    $this->logger->critical('Wrong cache frontend configuration for CodeQ_DeepLTranslationHelper_Translation cache defined!');
-                } catch (InvalidArgumentException $e) {
-                    $this->logger->critical($e->getMessage());
-                }
-            } catch (ClientException $e) {
-                if ($e->getResponse()->getStatusCode() === 403) {
-                    $this->logger->critical('Your DeepL API credentials are either wrong, or you don\'t have access to the requested API.');
-                } elseif ($e->getResponse()->getStatusCode() === 429) {
-                    $this->logger->warning('You sent too many requests to the DeepL API, we\'ll retry to connect to the API on the next request');
-                } elseif ($e->getResponse()->getStatusCode() === 456) {
-                    $this->logger->warning('You reached your DeepL API character limit. Upgrade your plan or wait until your quota is filled up again.');
-                } elseif ($e->getResponse()->getStatusCode() === 400) {
-                    $this->logger->warning('Your DeepL API request was not well-formed. Please check the source and the target language in particular.', [
-                        'sourceLanguage' => $sourceLanguage,
-                        'targetLanguage' => $targetLanguage
-                    ]);
-                } else {
-                    $this->logger->warning('The DeepL API request did not complete successfully, see status code and message below.', [
-                        'statusCode' => $e->getResponse()->getStatusCode(),
-                        'message' => $e->getResponse()->getBody()->getContents()
-                    ]);
-                }
-
-                // If the call went wrong, return the original text
-                $translatedText = $text;
-            } catch (GuzzleException $e) {
+            } else {
                 $this->logger->warning('The DeepL API request did not complete successfully, see status code and message below.', [
                     'statusCode' => $e->getResponse()->getStatusCode(),
                     'message' => $e->getResponse()->getBody()->getContents()
                 ]);
-
-                // If the call went wrong, return the original text
-                $translatedText = $text;
             }
+
+            // If the call went wrong, return the original text
+            $translatedText = $text;
+        } catch (GuzzleException $e) {
+            $this->logger->warning('The DeepL API request did not complete successfully, see status code and message below.', [
+                'statusCode' => $e->getResponse()->getStatusCode(),
+                'message' => $e->getResponse()->getBody()->getContents()
+            ]);
+
+            // If the call went wrong, return the original text
+            $translatedText = $text;
         }
 
         return $translatedText;

--- a/Classes/Domain/Service/NodeTranslationService.php
+++ b/Classes/Domain/Service/NodeTranslationService.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace CodeQ\DeepLTranslationHelper\Domain\Service;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Service\Context;
+
+class NodeTranslationService
+{
+
+    /**
+     * @Flow\Inject
+     * @var DeepLService
+     */
+    protected $deeplService;
+
+    /**
+     * @Flow\InjectConfiguration(path="translateRichtextProperties")
+     * @var bool
+     */
+    protected $translateRichtextProperties;
+
+    /**
+     * @param NodeInterface $node
+     * @param Context $context
+     * @param $recursive
+     * @return void
+     */
+    public function afterAdoptNode(NodeInterface $node, Context $context, $recursive)
+    {
+        $propertyDefinitions = $node->getNodeType()->getProperties();
+        $adoptedNode = $context->getNodeByIdentifier($node->getIdentifier());
+
+        $sourceLanguage = explode('_', $node->getContext()->getTargetDimensions()['language'])[0];
+        $targetLanguage = explode('_', $context->getTargetDimensions()['language'])[0];
+
+        foreach ($node->getProperties() as $propertyName => $propertyValue) {
+
+            if (empty($propertyValue)) {
+                continue;
+            }
+            if (!array_key_exists($propertyName, $propertyDefinitions)) {
+                continue;
+            }
+            if ($propertyDefinitions[$propertyName]['type'] != 'string' || !is_string($propertyValue)) {
+                continue;
+            }
+
+            $translateProperty = false;
+            $isInlineEditable = $propertyDefinitions[$propertyName]['ui']['inlineEditable'] ?? false;
+            $isTranslateEnabled = $propertyDefinitions[$propertyName]['options']['autotranslate'] ?? false;
+            if ($this->translateRichtextProperties && $isInlineEditable == true) {
+                $translateProperty = true;
+            }
+            if ($isTranslateEnabled) {
+                $translateProperty = true;
+            }
+
+            if ($translateProperty) {
+                $translatedValue = $this->deeplService->translate($propertyValue, $targetLanguage, $sourceLanguage);
+                $adoptedNode->setProperty($propertyName, $translatedValue);
+            }
+        }
+    }
+}

--- a/Classes/Domain/Service/NodeTranslationService.php
+++ b/Classes/Domain/Service/NodeTranslationService.php
@@ -35,7 +35,7 @@ class NodeTranslationService
         $sourceLanguage = explode('_', $node->getContext()->getTargetDimensions()['language'])[0];
         $targetLanguage = explode('_', $context->getTargetDimensions()['language'])[0];
 
-        foreach ($node->getProperties() as $propertyName => $propertyValue) {
+        foreach ($adoptedNode->getProperties() as $propertyName => $propertyValue) {
 
             if (empty($propertyValue)) {
                 continue;

--- a/Classes/EelHelper/TranslationHelper.php
+++ b/Classes/EelHelper/TranslationHelper.php
@@ -3,6 +3,7 @@
 namespace CodeQ\DeepLTranslationHelper\EelHelper;
 
 use CodeQ\DeepLTranslationHelper\Domain\Service\DeepLService;
+use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
 
@@ -15,6 +16,12 @@ class TranslationHelper implements ProtectedContextAwareInterface {
     protected $deepLService;
 
     /**
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $translationCache;
+
+    /**
      * @param string      $text
      * @param string      $targetLanguage
      * @param string|null $sourceLanguage
@@ -23,7 +30,14 @@ class TranslationHelper implements ProtectedContextAwareInterface {
      */
     public function translate(string $text, string $targetLanguage, string $sourceLanguage = null): string
     {
-        return $this->deepLService->translate($text, $targetLanguage, $sourceLanguage);
+        // See: https://ideone.com/embed/0iwuGn
+        $cacheIdentifier = sprintf('%s-%s-%s', hash('haval256,3', $text), $sourceLanguage, $targetLanguage);
+        if ($translatedText = $this->translationCache->get($cacheIdentifier)) {
+            return $translatedText;
+        }
+        $translatedText = $this->deepLService->translate($text, $targetLanguage, $sourceLanguage);
+        $this->translationCache->set($cacheIdentifier, $translatedText);
+        return $translatedText;
     }
 
     /**

--- a/Classes/EelHelper/TranslationHelper.php
+++ b/Classes/EelHelper/TranslationHelper.php
@@ -35,8 +35,8 @@ class TranslationHelper implements ProtectedContextAwareInterface {
         if ($translatedText = $this->translationCache->get($cacheIdentifier)) {
             return $translatedText;
         }
-        $translatedText = $this->deepLService->translate($text, $targetLanguage, $sourceLanguage);
-        $this->translationCache->set($cacheIdentifier, $translatedText);
+        $translatedTexts = $this->deepLService->translate(['text' => $text], $targetLanguage, $sourceLanguage);
+        $this->translationCache->set($cacheIdentifier, $translatedTexts['text']);
         return $translatedText;
     }
 

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -1,0 +1,23 @@
+<?php
+namespace CodeQ\DeepLTranslationHelper;
+
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Package\Package as BasePackage;
+use Neos\ContentRepository\Domain\Service\Context;
+use CodeQ\DeepLTranslationHelper\Domain\Service\NodeTranslationService;
+
+/**
+ * The Neos Package
+ */
+class Package extends BasePackage
+{
+    /**
+     * @param Bootstrap $bootstrap The current bootstrap
+     * @return void
+     */
+    public function boot(Bootstrap $bootstrap)
+    {
+        $dispatcher = $bootstrap->getSignalSlotDispatcher();
+        $dispatcher->connect(Context::class, 'afterAdoptNode', NodeTranslationService::class, 'afterAdoptNode');
+    }
+}

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,0 +1,11 @@
+'Neos.Neos:Document':
+  properties:
+    title:
+      options:
+        deeplTranslate: true
+    titleOverride:
+      options:
+        deeplTranslate: true
+    metaDescription:
+      options:
+        deeplTranslate: true

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,4 +1,4 @@
-CodeQ\DeepLTranslationHelper\Domain\Service\DeepLService:
+CodeQ\DeepLTranslationHelper\EelHelper\TranslationHelper:
   properties:
     translationCache:
       object:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,6 +3,7 @@ CodeQ:
     DeepLService:
       baseUri: 'https://api.deepl.com/v2/'
       apiAuthKey: ''
+    translateRichtextProperties: true
 
 Neos:
   Fusion:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,9 +1,20 @@
 CodeQ:
   DeepLTranslationHelper:
     DeepLService:
-      baseUri: 'https://api.deepl.com/v2/'
+      useFreeApi: false
       apiAuthKey: ''
-    translateRichtextProperties: true
+
+      baseUri: 'https://api.deepl.com/v2/'
+      baseUriFree: 'https://api-free.deepl.com/v2/'
+
+      defaultOptions:
+        tag_handling: 'xml'
+        split_sentences: 'nonewlines'
+        preserve_formatting: 1
+        formality: "default"
+
+    nodeTranslations:
+      translateInlineEditables: true
 
 Neos:
   Fusion:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using the free API, you need to change the baseUri:
 CodeQ:
   DeepLTranslationHelper:
     DeepLService:
-      baseUri: 'https://api-free.deepl.com/v2/'
+      useFreeApi: true
       apiAuthKey: 'myapikey'
 ```
 
@@ -49,4 +49,28 @@ CodeQ_DeepLTranslationHelper_Translation:
   backend: Neos\Cache\Backend\FileBackend
   backendOptions:
     defaultLifetime: 2592000
+```
+
+
+## Node Translations 
+
+When nodes are copied (adopted) into another languge the fields can be translated automatically.
+
+The following setting enables the translation of all inlineEditable properties. 
+
+```yaml
+CodeQ:
+  DeepLTranslationHelper:
+    nodeTranslations:
+      translateInlineEditables: true
+```
+
+Other properties of type string can be translated aswell with the following configuration.
+
+ ```yaml
+Neos.Neos:Document:
+   properties:
+     title:
+       options:
+         deeplTranslate: true
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "type": "neos-package",
     "name": "codeq/deepltranslationhelper",
     "require": {
-        "neos/flow": "*",
-        "guzzlehttp/guzzle": "^7.0"
+        "neos/flow": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "type": "neos-package",
     "name": "codeq/deepltranslationhelper",
     "require": {
-        "neos/flow": "*"
+        "neos/flow": "*",
+        "neos/http-factories": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "type": "neos-package",
     "name": "codeq/deepltranslationhelper",
     "require": {
-        "neos/flow": "*"
+        "neos/flow": "*",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Translate node properties while they are adopted to another language.

When nodes are copied (adopted) into another languge the fields can be translated automatically.

The following setting enables the translation of all inlineEditable properties: 

```yaml
CodeQ:
  DeepLTranslationHelper:
    nodeTranslations:
      translateInlineEditables: true
```

Other properties of type string can be translated aswell with the following configuration.

```yaml
Neos.Neos:Document:
   properties:
     title:
       options:
         deeplTranslate: true
```

In additions this PR:
- moves the caching to the eel helper 
- implements the deepl service with psr factories and request to avoid an explicit dependency to guzzle
- adds a Setting `CodeQ.DeepLTranslationHelper.DeepLService.useFreeApi: false` to switch between free and payed api
- adds a Setting `CodeQ.DeepLTranslationHelper.DeepLService.defaultOptions` to configure additional arguments for the translation